### PR TITLE
#55 Make TestMessageResponseType extend PayloadMessageResponseType

### DIFF
--- a/xsd/UFTP-common.xsd
+++ b/xsd/UFTP-common.xsd
@@ -224,7 +224,7 @@ SPDX-License-Identifier: Apache-2.0
     <!-- -->
     <xs:complexType name="TestMessageResponseType">
         <xs:complexContent>
-            <xs:extension base="PayloadMessageType"/>
+            <xs:extension base="PayloadMessageResponseType"/>
         </xs:complexContent>
     </xs:complexType>
     <!-- -->


### PR DESCRIPTION
Closes #55 

It is useful to see the difference between a request payload and a response payload (in the types).