### PR TITLE
fix: ensure basis Mike documentation versioning

### DIFF
--- a/.github/workflows/docs-development.yml
+++ b/.github/workflows/docs-development.yml
@@ -38,3 +38,5 @@ jobs:
         run: poetry run mike deploy --push --update-aliases development
         env:
           ENABLE_PDF_EXPORT: 1
+      - name: Set latest as default (should only have te be run once)
+        run: poetry run mike set-default --push latest


### PR DESCRIPTION
Call `poetry run mike set-default --push latest` at least once to setup the basis Mike structure in the repository.