### PR TITLE
docs: default version 'development'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
   custom_dir: overrides # to add the warning bar for the latest version
 extra:
   version:
+    default: development
     provider: mike
   social:
     # available icons in https://github.com/squidfunk/mkdocs-material/tree/master/material/.icons/fontawesome


### PR DESCRIPTION
Set default documentation version to 'development'. This should ensure that the header bar disappears for the development version. Related documentation: https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/#version-warning