### PR TITLE
fix: push default branch to 'latest'

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: docs-development
+name: docs-latest
 
 on:
   push:
@@ -32,9 +32,9 @@ jobs:
         run: |
           git config --global user.name Docs deploy
           git config --global user.email docs-action@shapshifter
-      - name: Push the main branch under the alias development
-        run: poetry run mike deploy --push --update-aliases development
+      - name: Push the main branch under the alias latest
+        run: poetry run mike deploy --push --update-aliases latest
         env:
           ENABLE_PDF_EXPORT: 1
       - name: Set latest as default (should only have te be run once)
-        run: poetry run mike set-default --push development
+        run: poetry run mike set-default --push latest


### PR DESCRIPTION
Somehow the 'development' version didn't work, as concluded in https://github.com/shapeshifter/shapeshifter-specification/pull/73 so configure it to the default that is used for other projects too.