### PR TITLE
chore: back to development version

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -32,9 +32,7 @@ jobs:
         run: |
           git config --global user.name Docs deploy
           git config --global user.email docs-action@shapshifter
-      - name: Push the main branch under the alias latest
-        run: poetry run mike deploy --push --update-aliases latest
+      - name: Push the main branch under the alias development
+        run: poetry run mike deploy --push --update-aliases development
         env:
           ENABLE_PDF_EXPORT: 1
-      - name: Set latest as default (should only have te be run once)
-        run: poetry run mike set-default --push latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,10 +17,11 @@ theme:
     - navigation.top # back-to-top button when scrolling back up
   logo: assets/images/shapeshifter-icon-white.svg
   favicon: assets/images/shapeshifter-icon-color.svg
-  custom_dir: overrides # to add the warning bar for the latest version
+  # TODO: enable this feature once versioned releases have been published
+  # custom_dir: overrides # to add the warning bar for the latest version
 extra:
   version:
-    default: latest
+    default: development
     provider: mike
   social:
     # available icons in https://github.com/squidfunk/mkdocs-material/tree/master/material/.icons/fontawesome


### PR DESCRIPTION
Back to development version, as the github releases will be labeld the 'latest' version already. So for example 'latest' will be an alias for v3.2.0 if v3.2.0 and v3.1.0 have been published.

To avoid confusion the override bar with the notification about not being on the latest release is disabled for now.

This pull-request is best complemented by a commit to the `gh-pages` branch to remove the publish under the name 'latest'.