### PR TITLE
chore: poetry package without root

### DIFF
--- a/.github/workflows/docs-latest.yml
+++ b/.github/workflows/docs-latest.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Poetry and dependencies
         run: |
           pip install poetry
-          poetry install --no-interaction --no-root
+          poetry install --no-interaction
       - name: Configure fake git user to associate commits
         run: |
           git config --global user.name Docs deploy

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Poetry and dependencies
         run: |
           pip install poetry
-          poetry install --no-interaction --no-root
+          poetry install --no-interaction
       - name: Create local documentation build
         run: poetry run mkdocs build
         env:

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Poetry and dependencies
         run: |
           pip install poetry
-          poetry install --no-interaction --no-root
+          poetry install --no-interaction
       - name: Configure fake git user to associate commits
         run: |
           git config --global user.name Docs deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = ""
 authors = ["\"Shapeshifter contributors\""]
 license = "\"Apache-2.0\""
 readme = "README.md"
+package-mode = false
 packages = [{include = "shapeshifter_specification"}]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Run poetry in non-package mode, available since Poetry 1.8.0 https://github.com/python-poetry/poetry/releases/tag/1.8.0